### PR TITLE
`__func__` overwritten, hurting error richness.

### DIFF
--- a/src/fallback.h
+++ b/src/fallback.h
@@ -28,7 +28,7 @@ int fish_wcswidth(const wchar_t *str, size_t n);
    be the currently compiled function. If we aren't using C99 or
    later, older versions of GCC had __FUNCTION__.
 */
-#if __STDC_VERSION__ < 199901L
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ < 199901L
 # if __GNUC__ >= 2
 #  define __func__ __FUNCTION__
 # else
@@ -71,8 +71,7 @@ struct winsize
        Number of columns
      */
     unsigned short ws_col;
-}
-;
+};
 
 #endif
 


### PR DESCRIPTION
# Solves issue #2919 by checking that `__STDC_VERSION__` is defined before overwriting `__func__`.

In C++ situations where `__STDC_VERSION__` is unset (as it should be),
fish was assuming we are on < C99 and setting it to `__FUNCTION__`.

Basically always, `__PRETTY_FUNCTION__` ends up reaplaced by `__FUNCTION__`, this hurt
error message usefulness and richness.

`__PRETTY_FUNCTION__`:  `const thing::sub(int)`
`__FUNCTION__`:         `sub`
